### PR TITLE
Fix markdown.properties

### DIFF
--- a/scite/markdown.properties
+++ b/scite/markdown.properties
@@ -1,4 +1,13 @@
-lexer.*.md=markdown
+file.patterns.md=*.md;*.markdown;
+file.patterns.md.like=$(file.patterns.md)
+
+filter.md=Markdown|$(file.patterns.md)|
+
+*filter.md=$(filter.md)
+
+lexer.$(file.patterns.md)=markdown
+
+*language.md=md|md||
 
 style.unknown=fore:#33FF00
 


### PR DESCRIPTION
markdown.properties was not working for me. I edited the opening section so it takes the same form as r.properties. (I was blindly copying with substitutes, so don't really know why this edited version works but the original version didn't.)